### PR TITLE
feature/github-oauth

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,8 @@ module.exports = {
     'import/prefer-default-export': 'off',
     'react-hooks/exhaustive-deps': 'off',
     'react/jsx-props-no-spreading': 'off',
+    '@typescript-eslint/ban-ts-comment': 'off',
+    'consistent-return': 'off',
   },
   parserOptions: {
     ecmaVersion: 2020,

--- a/package.json
+++ b/package.json
@@ -102,8 +102,10 @@
   },
   "dependencies": {
     "@carbon/icons-react": "^11.7.0",
+    "@electron-utils/electron-oauth-github": "^0.2.4",
     "@tanstack/react-query": "^4.1.0",
     "axios": "^0.27.2",
+    "cookiejs": "^2.1.2",
     "electron-debug": "^3.2.0",
     "electron-log": "^4.4.7",
     "electron-updater": "^5.0.3",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12,9 +12,10 @@ import path from 'path';
 import { app, BrowserWindow, shell, ipcMain } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
+// @ts-ignore
+import { getAccessToken } from '@electron-utils/electron-oauth-github';
 import MenuBuilder from './menu';
 import { resolveHtmlPath } from './util';
-import { getAccessToken } from '@electron-utils/electron-oauth-github';
 
 class AppUpdater {
   constructor() {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -14,6 +14,7 @@ import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
 import MenuBuilder from './menu';
 import { resolveHtmlPath } from './util';
+import { getAccessToken } from '@electron-utils/electron-oauth-github';
 
 class AppUpdater {
   constructor() {
@@ -93,6 +94,19 @@ const createWindow = async () => {
       mainWindow.show();
     }
   });
+
+  try {
+    const { access_token: accessToken } = await getAccessToken({
+      clientId: process.env.GITHUB_OAUTH_CLIENT_ID,
+      clientSecret: process.env.GITHUB_OAUTH_SECRET,
+      redirectUri: 'http://localhost:1212/',
+    });
+
+    mainWindow.webContents.send('accessToken', accessToken);
+  } catch (error) {
+    console.log('error happened');
+    console.log(error);
+  }
 
   mainWindow.on('closed', () => {
     mainWindow = null;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,17 +7,9 @@ import UserProfile from '@UserProfile/components';
 import UserContextProvider, { UserContext } from '@shared/contexts/UserContext';
 import '@shared/styles/index.scss';
 import { useContext } from 'react';
-import cookie from 'cookiejs';
 
 const Main = () => {
   const { hasUserId } = useContext(UserContext);
-
-  const { electron } = window;
-
-  electron.ipcRenderer.on('accessToken', (payload) => {
-    if (!payload) return;
-    cookie.set('access_token', payload as string);
-  });
 
   if (!hasUserId) return <Registration />;
 
@@ -36,6 +28,7 @@ export default function App() {
       queries: {
         refetchInterval: 1000 * 60 * 15,
         refetchOnWindowFocus: false,
+        retry: 10,
       },
     },
   });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,9 +7,17 @@ import UserProfile from '@UserProfile/components';
 import UserContextProvider, { UserContext } from '@shared/contexts/UserContext';
 import '@shared/styles/index.scss';
 import { useContext } from 'react';
+import cookie from 'cookiejs';
 
 const Main = () => {
   const { hasUserId } = useContext(UserContext);
+
+  const { electron } = window;
+
+  electron.ipcRenderer.on('accessToken', (payload) => {
+    if (!payload) return;
+    cookie.set('access_token', payload as string);
+  });
 
   if (!hasUserId) return <Registration />;
 

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from 'react-dom/client';
+import cookie from 'cookiejs';
 import App from './App';
 
 const container = document.getElementById('root')!;
@@ -11,3 +12,8 @@ window.electron.ipcRenderer.once('ipc-example', (arg) => {
   console.log(arg);
 });
 window.electron.ipcRenderer.sendMessage('ipc-example', ['ping']);
+
+window.electron.ipcRenderer.on('accessToken', (payload) => {
+  if (!payload) return;
+  cookie.set('accessToken', payload as string);
+});

--- a/src/renderer/shared/apis/index.ts
+++ b/src/renderer/shared/apis/index.ts
@@ -1,11 +1,16 @@
 import axios from 'axios';
+import cookie from 'cookiejs';
 
 const BASE_URL = 'https://api.github.com';
+
+const getAccessToken = () => {
+  return cookie.get('accessToken');
+};
 
 const axiosInstance = axios.create({
   baseURL: BASE_URL,
   headers: {
-    Authorization: `Token ${process.env.ELECTRON_GITHUB_DEVELOP_TOKEN}`,
+    Authorization: `Token ${getAccessToken()}`,
   },
 });
 

--- a/src/renderer/shared/apis/index.ts
+++ b/src/renderer/shared/apis/index.ts
@@ -1,17 +1,30 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import cookie from 'cookiejs';
 
 const BASE_URL = 'https://api.github.com';
 
-const getAccessToken = () => {
+export const getAccessToken = () => {
   return cookie.get('accessToken');
 };
 
 const axiosInstance = axios.create({
   baseURL: BASE_URL,
-  headers: {
-    Authorization: `Token ${getAccessToken()}`,
-  },
+  headers: {},
+});
+
+axiosInstance.interceptors.request.use((config: AxiosRequestConfig) => {
+  if (!config || !config.headers) {
+    throw new Error(
+      "Expected 'config' and 'config.headers' not to be undefined"
+    );
+  }
+  const accessToken = getAccessToken();
+
+  if (accessToken) return;
+
+  config.headers.Authorization = `Token ${accessToken}`;
+
+  return config;
 });
 
 export default axiosInstance;

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,6 +343,13 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@electron-utils/electron-oauth-github@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@electron-utils/electron-oauth-github/-/electron-oauth-github-0.2.4.tgz#6a57371c1648ddd749bed942ccb93d11e58ee384"
+  integrity sha512-LqeozRNZvshD6FR5RDE8++Ypk3vTz1A+g5zXVkKy3p2vUpoV00Cu4ibO78AL8SM4Pj70bDdc3CXMvT0FSqDfLg==
+  dependencies:
+    isomorphic-fetch "^3.0.0"
+
 "@electron/get@^1.13.0":
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.14.1.tgz#16ba75f02dffb74c23965e72d617adc721d27f40"
@@ -2915,6 +2922,11 @@ cookie@0.5.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
+cookiejs@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/cookiejs/-/cookiejs-2.1.2.tgz#51af70368e22064321b3b91159517d5bf6bef189"
+  integrity sha512-FXsQ2Ub/bTjlt2aXiJsiT33g6iEXdYTIKabJa9Jn5CZjOyzszJjOGKWyqs+silY+xYmA9eiif2vGAxv2pJndcg==
+
 core-js-pure@^3.20.2, core-js-pure@^3.8.1:
   version "3.23.5"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.23.5.tgz#23daaa9af9230e50f10b0fa4b8e6b87402be4c33"
@@ -5456,6 +5468,14 @@ isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
+
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
@@ -9279,6 +9299,11 @@ whatwg-encoding@^2.0.0:
   integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
   dependencies:
     iconv-lite "0.6.3"
+
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
### 이슈 기록

[@electron-utils/electron-oauth-github](https://www.npmjs.com/package/@electron-utils/electron-oauth-github)를 통해 github oauth를 구현하였다. 
github api graphql을 사용하려면 authorization이 필요했는데, 여기서 토큰을 어떻게 가져올 수 있을 지 고민이었다.
우선, 앱이 실행될 때 github oauth 처리를 해서 acceeToken을 쿠키에서 관리할 수 있도록 구현하였고, 
이어서, Axios interceptor 에서 토큰을 취해 모든 요청 해더에 토큰이 전달될 수 있도록 구현하였다.