### PR TITLE
Enhance/suspense

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     'react/jsx-props-no-spreading': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
     'consistent-return': 'off',
+    'react/require-default-props': 'off',
   },
   parserOptions: {
     ecmaVersion: 2020,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,6 +7,7 @@ import UserProfile from '@UserProfile/components';
 import UserContextProvider, { UserContext } from '@shared/contexts/UserContext';
 import '@shared/styles/index.scss';
 import { useContext } from 'react';
+import SuspenseBoundary from '@shared/boundaries/SuspenseBoundary';
 
 const Main = () => {
   const { hasUserId } = useContext(UserContext);
@@ -15,9 +16,10 @@ const Main = () => {
 
   return (
     <>
-      <h1>테스트입니다</h1>
       <ThemeSwitch />
-      <UserProfile />
+      <SuspenseBoundary fallbackStyle={{ width: 360, height: 360 }}>
+        <UserProfile />
+      </SuspenseBoundary>
     </>
   );
 };
@@ -28,7 +30,6 @@ export default function App() {
       queries: {
         refetchInterval: 1000 * 60 * 15,
         refetchOnWindowFocus: false,
-        retry: 10,
       },
     },
   });

--- a/src/renderer/UserProfile/components/Profile.tsx
+++ b/src/renderer/UserProfile/components/Profile.tsx
@@ -9,7 +9,7 @@ type ProfileProps = {
 
 const Profile = ({ userName, htmlUrl, blogUrl }: ProfileProps) => {
   return (
-    <>
+    <div className="profile">
       <div className="profile__user-name">{userName}</div>
       <Link className="profile__link" href={htmlUrl}>
         <Home />
@@ -19,7 +19,7 @@ const Profile = ({ userName, htmlUrl, blogUrl }: ProfileProps) => {
         <Blog />
         {blogUrl}
       </Link>
-    </>
+    </div>
   );
 };
 

--- a/src/renderer/UserProfile/components/index.tsx
+++ b/src/renderer/UserProfile/components/index.tsx
@@ -9,18 +9,14 @@ const UserProfile = () => {
   const { userId } = useContext(UserContext);
   const { user } = useUser(userId);
 
-  if (!user) return null;
-
   return (
     <section className="user-profile">
       <Avatar sourceUrl={user.avatar_url} />
-      <div className="profile">
-        <Profile
-          userName={user.login}
-          htmlUrl={user.html_url}
-          blogUrl={user.blog}
-        />
-      </div>
+      <Profile
+        userName={user.login}
+        htmlUrl={user.html_url}
+        blogUrl={user.blog}
+      />
     </section>
   );
 };

--- a/src/renderer/UserProfile/queries/useUser.ts
+++ b/src/renderer/UserProfile/queries/useUser.ts
@@ -9,6 +9,7 @@ const useUser = (userId: string) => {
       return data;
     },
     enabled: !!userId,
+    suspense: true,
   });
 
   return { user };

--- a/src/renderer/shared/apis/index.ts
+++ b/src/renderer/shared/apis/index.ts
@@ -20,7 +20,7 @@ axiosInstance.interceptors.request.use((config: AxiosRequestConfig) => {
   }
   const accessToken = getAccessToken();
 
-  if (accessToken) return;
+  if (!accessToken) return;
 
   config.headers.Authorization = `Token ${accessToken}`;
 

--- a/src/renderer/shared/boundaries/ErrorBoundary.tsx
+++ b/src/renderer/shared/boundaries/ErrorBoundary.tsx
@@ -1,0 +1,63 @@
+import React, { CSSProperties, ReactNode } from 'react';
+import Error from '../components/Error';
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+  reset?: (args?: unknown[]) => void;
+  fallbackStyle?: CSSProperties;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+  error: any;
+  errorMessage: string | null;
+};
+
+const initialState: ErrorBoundaryState = {
+  hasError: false,
+  error: null,
+  errorMessage: null,
+};
+
+class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = initialState;
+  }
+
+  static getDerivedStateFromError(error: any) {
+    return {
+      hasError: true,
+      error,
+      errorMessage: typeof error.message === 'string' ? error.message : null,
+    };
+  }
+
+  resetErrorBoundaryState = () => {
+    const { reset } = this.props;
+    this.setState({ ...initialState });
+    if (reset) reset();
+  };
+
+  render() {
+    const { hasError, error, errorMessage } = this.state;
+    const { children, fallbackStyle } = this.props;
+
+    if (hasError && error) {
+      return (
+        <Error
+          errorMessage={errorMessage}
+          reset={this.resetErrorBoundaryState}
+          style={fallbackStyle}
+        />
+      );
+    }
+
+    return children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/renderer/shared/boundaries/SuspenseBoundary.tsx
+++ b/src/renderer/shared/boundaries/SuspenseBoundary.tsx
@@ -1,0 +1,25 @@
+import { CSSProperties, ReactNode, Suspense } from 'react';
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
+import ErrorBoundary from './ErrorBoundary';
+import Loader from '../components/Loader';
+
+type SuspenseBoundaryProps = {
+  children: ReactNode;
+  fallbackStyle?: CSSProperties;
+};
+
+const SuspenseBoundary = ({
+  children,
+  fallbackStyle,
+}: SuspenseBoundaryProps) => {
+  const { reset } = useQueryErrorResetBoundary();
+  return (
+    <ErrorBoundary reset={reset} fallbackStyle={fallbackStyle}>
+      <Suspense fallback={<Loader style={fallbackStyle} />}>
+        {children}
+      </Suspense>
+    </ErrorBoundary>
+  );
+};
+
+export default SuspenseBoundary;

--- a/src/renderer/shared/components/Error/index.scss
+++ b/src/renderer/shared/components/Error/index.scss
@@ -1,0 +1,24 @@
+@import '@shared/styles/variables.scss';
+
+.error {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  &__message {
+    font-size: $size-100;
+    color: $color-400;
+    margin-bottom: $size-100;
+  }
+
+  svg {
+    height: $size-300;
+    width: $size-300;
+    cursor: pointer;
+
+    path {
+      color: $color-200;
+    }
+  }
+}

--- a/src/renderer/shared/components/Error/index.tsx
+++ b/src/renderer/shared/components/Error/index.tsx
@@ -1,0 +1,20 @@
+import { CSSProperties } from 'react';
+import { Renew } from '@carbon/icons-react';
+import './index.scss';
+
+type ErrorFallbackProps = {
+  errorMessage: string | null;
+  reset: () => void;
+  style?: CSSProperties;
+};
+
+const Error = ({ errorMessage, reset, style }: ErrorFallbackProps) => {
+  return (
+    <section className="error" style={style}>
+      <div className="error__message">{errorMessage}</div>
+      <Renew onClick={reset} />
+    </section>
+  );
+};
+
+export default Error;

--- a/src/renderer/shared/components/Loader/index.scss
+++ b/src/renderer/shared/components/Loader/index.scss
@@ -1,10 +1,10 @@
 @import '@shared/styles/index.scss';
 
 .loader {
-  display: inline-block;
+  display: flex;
   position: relative;
-  width: $size-400;
-  height: $size-400;
+  justify-content: center;
+  align-items: center;
 
   div {
     box-sizing: border-box;

--- a/src/renderer/shared/components/Loader/index.tsx
+++ b/src/renderer/shared/components/Loader/index.tsx
@@ -1,8 +1,13 @@
+import { CSSProperties } from 'react';
 import './index.scss';
 
-const Loader = () => {
+type LoaderProps = {
+  style?: CSSProperties;
+};
+
+const Loader = ({ style }: LoaderProps) => {
   return (
-    <div className="loader">
+    <div className="loader" style={style}>
       <div />
       <div />
       <div />

--- a/src/renderer/shared/styles/index.scss
+++ b/src/renderer/shared/styles/index.scss
@@ -16,9 +16,15 @@ body {
   -webkit-text-size-adjust: antialiased;
   -moz-osx-font-smoothing: grayscale;
   transition: background-color 0.3s, color 0.3s;
+  padding: 4rem;
 }
 
 a {
   color: $color-100;
   text-decoration: none;
+}
+
+// ! disable react error overlay in development
+iframe {
+  display: none;
 }


### PR DESCRIPTION
resolve #7 

### 이슈 기록

suspense, error boundary를 적용했다. 쿼리를 통해 패칭하는 데이터를 기다리고,
에러가 전역으로 번지는 것을 막아 특정 섹션에서 에러를 핸들링하고 다시 패칭을 시도할 수 있도록 구현하였다.

error boundary에 대한 내용은 [TIL/react/01_error-boundaries](https://github.com/youthfulhps/TIL/tree/main/react/01_error-boundaries)에 정리해두었지만,
suspense의 경우 아직 정리하지 못했으므로, 본 PR은 suspense에 대한 내용이 정리되는대로 머지할 예정!