### PR TITLE
revert/github-authorization

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "package": "ts-node ./.erb/scripts/clean.js dist && npm run build && electron-builder build --publish never",
     "prepare": "husky install",
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir release/app",
-    "start": "ts-node ./.erb/scripts/check-port-in-use.js && npm run start:renderer",
+    "start": "cross-env NODE_ENV=development ts-node ./.erb/scripts/check-port-in-use.js && npm run start:renderer",
     "start:main": "cross-env NODE_ENV=development electronmon -r ts-node/register/transpile-only .",
     "start:preload": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.preload.dev.ts",
     "start:renderer": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack serve --config ./.erb/configs/webpack.config.renderer.dev.ts",

--- a/src/renderer/shared/apis/index.ts
+++ b/src/renderer/shared/apis/index.ts
@@ -18,7 +18,12 @@ axiosInstance.interceptors.request.use((config: AxiosRequestConfig) => {
       "Expected 'config' and 'config.headers' not to be undefined"
     );
   }
-  const accessToken = getAccessToken();
+
+  const isDev = process.env.NODE_ENV === 'development';
+
+  const accessToken = isDev
+    ? process.env.ELECTRON_GITHUB_DEVELOP_TOKEN
+    : getAccessToken();
 
   if (!accessToken) return;
 


### PR DESCRIPTION
### 이슈 기록

욕심이 큰 지 여러 플랫폼에서 기능을 가져다가 사용하기엔, electron-oauth를 사용하는 건 적합하지 않다고 판단된다..
accessToken을 쿠키에서 가져다 사용했는데, 우선 개발 단계에서 정확하게는 github oauth를 구현하기 전까지는 
로컬에 env 파일에서 꺼내와 사용하자ㅠ